### PR TITLE
Shallow rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Jest Marko transformer & rendering test utility.
 
 ## What is this?
 
-Contains transformer and other rendering test utility for testing [Marko 4](https://markojs.com/) component with Jest & JSDOM. 
+Contains transformer and other rendering test utility for testing [Marko 4](https://markojs.com/) component with Jest & JSDOM.
 
 ## Requirements
 
@@ -352,6 +352,72 @@ describe('test-simple-button', () => {
 });
 ```
 
+## Shallow Rendering
+
+marko-jest can do [shallow rendering](https://reactjs.org/docs/shallow-renderer.html) on external component. If you use external Marko component module/library (such as [ebayui-core](https://github.com/eBay/ebayui-core)), you can exclude those components from being rendered deeply by adding the module name to Jest globals config `taglibExcludePackages`. marko-jest will use Marko's [`taglibFinder.excludePackage()`](https://markojs.com/docs/custom-tags/#hiding-taglibs) to prevent any components from those modules to be rendered.
+
+For example, if you want to do shallow rendering on all components from `@ebay/ebayui-core` module, add the module name to Jest globals config:
+
+```json
+// package.json
+{
+  ...
+
+  "jest": {
+    "transform": {
+      ...
+    },
+    ...
+    "globals": {
+      "marko-jest": {
+        "taglibExcludePackages": [
+          "@ebay/ebayui-core",
+          "marko-material"
+        ]
+      }
+    }
+  },
+
+  ...
+}
+```
+
+Now Marko Jest will render your component:
+
+```html
+// cta-component.marko
+<section>
+  <ebay-button priority="primary" on-click('toggleButton')>
+    PAY
+  </ebay-button>
+</section>
+```
+
+As:
+
+```html
+<section>
+  <ebay-button priority="primary">PAY</ebay-button>
+<section>
+```
+
+Instead of
+
+```html
+<section>
+  <button type="button" class="btn btn--primary">PAY</button>
+<section>
+```
+
+One of the advantages of shallow rendering is to isolate your unit test so you can focus on testing your component instead of the external ones. On the example above, if the `ebay-button` implementation has changed (e.g css class name or new attribute added), your snapshot test will not failed.
+
+### Current Limitation of marko-jest shallow rendering
+
+- The shallow rendering will affect ALL test suites, you cannot turn it on or off
+ during runtime.
+- You can only do shallow rendering on external modules. Unfortunately, you cannot do shallow rendering on component from the same project. The only workaround so far is to separate your UI component as external module (npm package) and consume it on your project.
+
+
 ## marko-jest APIs
 
 marko-jest API provides 2 APIs:
@@ -372,17 +438,15 @@ The test sandbox is basically an empty div container where the tested component 
 
 ## Known Issues
 
-* Fixed on [version 3](https://github.com/abiyasa/marko-jest/releases/tag/v3.0.0). ~~Component with nesting components~~
-  - ~~The nesting components are rendered properly, however the instances are not properly created. Therefore, when parent component calls `getComponent()` or `getComponents()`, it will get undefined. The workaround is to stub/mock the parent's component `getComponent()` with a mocked component.~~
-* Does not support excluding specific tag yet (through Marko `excludeDir()` or `excludePackage()`), see https://github.com/abiyasa/marko-jest/issues/1
 * Failed rendering Marko component with custom transformer
+* Limited support of shallow rendering, see Shallow Rendering above or https://github.com/abiyasa/marko-jest/issues/1
 
 ## Roadmap
 
 Planned new features and improvements:
 
 * API simplification: remove test sandbox.
-* Support shallow and deep rendering. Currently, the default behaviour is deep rendering. Shallow rendering is not supported yet.
+* Better support of shallow and deep rendering.
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "marko": "^4.9.0"
   },
   "devDependencies": {
+    "@ebay/ebayui-core": "^0.9.1",
     "coveralls": "^3.0.0",
     "eslint": "^4.10.0",
     "eslint-config-airbnb-base": "^12.1.0",
@@ -50,6 +51,13 @@
       "<rootDir>",
       "<rootDir>/src"
     ],
+    "globals": {
+      "marko-jest": {
+        "taglibExcludePackages": [
+          "@ebay/ebayui-core"
+        ]
+      }
+    },
     "moduleFileExtensions": [
       "js",
       "json"

--- a/src/__tests__/preprocessor.spec.js
+++ b/src/__tests__/preprocessor.spec.js
@@ -1,15 +1,59 @@
+jest.mock('marko/compiler');
+
+const compiler = require('marko/compiler');
+const preprocessor = require('../preprocessor');
+
 describe('preprocessor', () => {
-  const mockedMarkoCompiler = {
-    compileFileForBrowser: jest.fn()
-  };
-  jest.mock('marko/compiler', () => mockedMarkoCompiler);
+  beforeEach(() => {
+    compiler.compileFileForBrowser = jest.fn();
+  });
 
-  // eslint-disable-next-line global-require
-  const preprocessor = require('../preprocessor');
+  afterEach(() => {
+    compiler.compileFileForBrowser.mockRestore();
+  });
 
-  it('should compile Marko file with ouput to vdom', () => {
+  it('should compile Marko file', () => {
     const filepath = 'src/file/path';
+
     preprocessor.process('source', filepath);
-    expect(mockedMarkoCompiler.compileFileForBrowser).toHaveBeenCalledWith(filepath);
+    expect(compiler.compileFileForBrowser).toHaveBeenCalledWith(filepath, undefined);
+  });
+
+  describe('given taglibExcludePackages is defined', () => {
+    const filepath = 'src/file/path';
+    const jestConfig = {
+      globals: {
+        'marko-jest': {
+          taglibExcludePackages: [
+            '@ebay/ebayui-core',
+            'material-marko'
+          ]
+        }
+      }
+    };
+
+    beforeEach(() => {
+      compiler.taglibFinder.excludePackage = jest.fn();
+
+      preprocessor.process('source', filepath, jestConfig);
+    });
+
+    afterEach(() => {
+      compiler.taglibFinder.excludePackage.mockRestore();
+    });
+
+    it('should register excluded packages to marko compiler', () => {
+      expect(compiler.taglibFinder.excludePackage).toHaveBeenCalledTimes(2);
+
+      const { calls } = compiler.taglibFinder.excludePackage.mock;
+      expect(calls).toEqual([['@ebay/ebayui-core'], ['material-marko']]);
+    });
+
+    it('should compile Marko file with the right compiler option', () => {
+      expect(compiler.compileFileForBrowser).toHaveBeenCalledWith(
+        filepath,
+        { ignoreUnrecognizedTags: true }
+      );
+    });
   });
 });

--- a/src/preprocessor.js
+++ b/src/preprocessor.js
@@ -8,7 +8,7 @@ module.exports = {
     let compileOption;
     const { taglibExcludePackages } = markoJestCfg;
     if (taglibExcludePackages) {
-      taglibExcludePackages.forEach(package => compiler.taglibFinder.excludePackage(package));
+      taglibExcludePackages.forEach(pkg => compiler.taglibFinder.excludePackage(pkg));
 
       compileOption = { ignoreUnrecognizedTags: true };
     }

--- a/src/preprocessor.js
+++ b/src/preprocessor.js
@@ -2,9 +2,19 @@ const compiler = require('marko/compiler');
 
 // Jest helper to compile Marko
 module.exports = {
-  process(src, filepath) {
+  process(src, filepath, jestCfg = {}) {
+    const markoJestCfg = (jestCfg.globals && jestCfg.globals['marko-jest']) || {};
+
+    let compileOption;
+    const { taglibExcludePackages } = markoJestCfg;
+    if (taglibExcludePackages) {
+      taglibExcludePackages.forEach(package => compiler.taglibFinder.excludePackage(package));
+
+      compileOption = { ignoreUnrecognizedTags: true };
+    }
+
     // NOTE: need to render to vdom so rendering to JSDOM works
-    const compiledSrc = compiler.compileFileForBrowser(filepath);
+    const compiledSrc = compiler.compileFileForBrowser(filepath, compileOption);
     return compiledSrc;
   },
 };

--- a/test/__snapshots__/external-component.spec.js.snap
+++ b/test/__snapshots__/external-component.spec.js.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`external-component on rendering should render correctly 1`] = `
+Array [
+  <ebay-button
+    priority="primary"
+  >
+    Click me
+  </ebay-button>,
+]
+`;
+
+exports[`external-component on triggering click handler should update the element 1`] = `
+Array [
+  <ebay-button
+    priority="primary"
+  >
+    DONE
+  </ebay-button>,
+]
+`;

--- a/test/external-component.spec.js
+++ b/test/external-component.spec.js
@@ -1,0 +1,45 @@
+const path = require('path');
+const { initComponent, createTestSandbox } = require('../test-utils');
+
+describe('external-component', () => {
+  const componentClass = initComponent(path.resolve(__dirname, './resources/external-component/index.marko'));
+
+  let testSandbox;
+  let component;
+
+  beforeEach(() => {
+    testSandbox = createTestSandbox();
+  });
+
+  afterEach(() => {
+    testSandbox.reset();
+  });
+
+  describe('on rendering', () => {
+    beforeEach(async () => {
+      component = await testSandbox.renderComponent(componentClass, {});
+    });
+
+    it('should render correctly', () => {
+      expect(testSandbox.getRenderedNodes()).toMatchSnapshot();
+    });
+  });
+
+  describe('on triggering click handler', () => {
+    beforeEach(async () => {
+      component = await testSandbox.renderComponent(componentClass, {});
+
+      component.el.click();
+      component.update();
+    });
+
+    it('should update the element', () => {
+      expect(testSandbox.getRenderedNodes()).toMatchSnapshot();
+    });
+
+    it('should change the button label', () => {
+      const buttonLabel = component.el.textContent;
+      expect(buttonLabel).toEqual('DONE');
+    });
+  });
+});

--- a/test/resources/external-component/component.js
+++ b/test/resources/external-component/component.js
@@ -1,0 +1,11 @@
+module.exports = {
+  onCreate() {
+    this.state = {
+      clicked: false
+    };
+  },
+
+  toggleButton() {
+    this.state.clicked = !this.state.clicked;
+  }
+};

--- a/test/resources/external-component/index.marko
+++ b/test/resources/external-component/index.marko
@@ -1,0 +1,3 @@
+<ebay-button priority="primary" on-click('toggleButton')>
+  ${state.clicked ? 'DONE' : 'Click me'}
+</ebay-button>

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,6 +16,21 @@
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
+"@ebay/ebayui-core@^0.9.1":
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/@ebay/ebayui-core/-/ebayui-core-0.9.1.tgz#31dd2a16b4eb19ebd8faa03d822c51ec160f11b9"
+  dependencies:
+    lodash.get "^4.4.2"
+    lodash.set "^4.3.2"
+    makeup-expander "~0.4.0"
+    makeup-focusables "~0.0.3"
+    makeup-key-emitter "~0.0.3"
+    makeup-keyboard-trap "~0.1.0"
+    makeup-prevent-scroll-keys "~0.0.2"
+    makeup-roving-tabindex "~0.0.5"
+    makeup-screenreader-trap "~0.0.5"
+    nodelist-foreach-polyfill "^1.2.0"
+
 abab@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.4.tgz#5faad9c2c07f60dd76770f71cf025b62a63cfd4e"
@@ -709,6 +724,10 @@ cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
   resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-0.2.37.tgz#541097234cb2513c83ceed3acddc27ff27987d54"
   dependencies:
     cssom "0.3.x"
+
+custom-event-polyfill@^0.3.0, custom-event-polyfill@~0.3:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/custom-event-polyfill/-/custom-event-polyfill-0.3.0.tgz#99807839be62edb446b645832e0d80ead6fa1888"
 
 dashdash@^1.12.0:
   version "1.14.1"
@@ -2317,6 +2336,14 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
+lodash.get@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+
+lodash.set@^4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/lodash.set/-/lodash.set-4.3.2.tgz#d8757b1da807dde24816b0d6a84bea1a76230b23"
+
 lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
@@ -2351,6 +2378,67 @@ makeerror@1.0.x:
   resolved "https://registry.yarnpkg.com/makeerror/-/makeerror-1.0.11.tgz#e01a5c9109f2af79660e4e8b9587790184f5a96c"
   dependencies:
     tmpl "1.0.x"
+
+makeup-exit-emitter@~0.0, makeup-exit-emitter@~0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/makeup-exit-emitter/-/makeup-exit-emitter-0.0.4.tgz#26482e73db3ef6ef5f8ac2c3c21e8197488fd458"
+  dependencies:
+    custom-event-polyfill "~0.3"
+    makeup-next-id "~0.0"
+
+makeup-expander@~0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/makeup-expander/-/makeup-expander-0.4.0.tgz#8f810be697dc1c2dc279a43e442b74f7cf414292"
+  dependencies:
+    custom-event-polyfill "~0.3"
+    makeup-exit-emitter "~0.0.4"
+    makeup-focusables "~0.0.3"
+    makeup-next-id "~0.0.2"
+
+makeup-focusables@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/makeup-focusables/-/makeup-focusables-0.0.3.tgz#e30f36a99beb7c5166daafb8f823fefcc7a551fa"
+
+makeup-key-emitter@~0.0, makeup-key-emitter@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/makeup-key-emitter/-/makeup-key-emitter-0.0.3.tgz#4fe16127cce749a785f4e2538800415d267fd356"
+  dependencies:
+    custom-event-polyfill "~0.3"
+
+makeup-keyboard-trap@~0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/makeup-keyboard-trap/-/makeup-keyboard-trap-0.1.0.tgz#0ef20b6672b877771a3c24f998740158165f1d00"
+  dependencies:
+    custom-event-polyfill "~0.3"
+    makeup-focusables "~0.0.3"
+
+makeup-navigation-emitter@~0.0:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/makeup-navigation-emitter/-/makeup-navigation-emitter-0.0.6.tgz#befcc18d31ee125c332307fb7c304cddbfab4bda"
+  dependencies:
+    custom-event-polyfill "^0.3.0"
+    makeup-exit-emitter "~0.0"
+    makeup-key-emitter "~0.0"
+
+makeup-next-id@~0.0, makeup-next-id@~0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/makeup-next-id/-/makeup-next-id-0.0.2.tgz#70f19812b0b5cb8d5f0f7f78719179ea4b61a0ef"
+
+makeup-prevent-scroll-keys@~0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/makeup-prevent-scroll-keys/-/makeup-prevent-scroll-keys-0.0.2.tgz#1c255e5f97968ee3586c0aa55d0d8b3df8318501"
+
+makeup-roving-tabindex@~0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/makeup-roving-tabindex/-/makeup-roving-tabindex-0.0.5.tgz#5bd855216eed374846b5d26466488ee0b6aeed0e"
+  dependencies:
+    makeup-navigation-emitter "~0.0"
+
+makeup-screenreader-trap@~0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/makeup-screenreader-trap/-/makeup-screenreader-trap-0.0.5.tgz#f5f21d0da15092905c3febf83bb03bf7adde037b"
+  dependencies:
+    custom-event-polyfill "~0.3"
 
 map-cache@^0.2.2:
   version "0.2.2"
@@ -2580,6 +2668,10 @@ node-pre-gyp@^0.10.0:
     rimraf "^2.6.1"
     semver "^5.3.0"
     tar "^4"
+
+nodelist-foreach-polyfill@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/nodelist-foreach-polyfill/-/nodelist-foreach-polyfill-1.2.0.tgz#92bca739959af68271734087e48474c2fef5152c"
 
 nopt@^4.0.1:
   version "4.0.1"


### PR DESCRIPTION
Support shallow rendering by using Marko `taglibFinder.excludePackage()`

- Add module name to Jest globals `marko-jest` > `taglibExcludePackages`. All components from that module/package will be shallow rendered
